### PR TITLE
Add logging system with reporters, plugin extension, and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # Test
-Test
+
+Basic event engine with configurable logging and pluggable reporters.
+
+```python
+from logging import configure
+from engine import Engine
+from reports import JSONReporter, TextReporter
+
+configure('debug')
+engine = Engine()
+engine.register_reporter(TextReporter())
+engine.register_reporter(JSONReporter('events.json'))
+engine.emit('started', {'foo': 'bar'})
+engine.finalize()
+```
+
+## Command-line interface
+
+A simple interactive interface is provided via ``ui.py``:
+
+```bash
+python ui.py --json events.json --log-level debug
+```
+
+Type event names optionally followed by JSON data and finish with ``quit``.

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,3 @@
+from .engine import Engine
+
+__all__ = ["Engine"]

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -1,0 +1,27 @@
+from typing import Any, List
+
+from reports.base import Reporter
+
+
+class Engine:
+    """Simple event-driven engine."""
+
+    def __init__(self) -> None:
+        self.reporters: List[Reporter] = []
+
+    # Reporter registration
+    def register_reporter(self, reporter: Reporter) -> None:
+        self.reporters.append(reporter)
+
+    # Plugin registration
+    def register_plugin(self, plugin: 'Plugin') -> None:  # noqa: F821
+        plugin.register(self)
+
+    # Event emission
+    def emit(self, event: str, data: Any = None) -> None:
+        for reporter in self.reporters:
+            reporter.handle(event, data)
+
+    def finalize(self) -> None:
+        for reporter in self.reporters:
+            reporter.finalize()

--- a/logging/__init__.py
+++ b/logging/__init__.py
@@ -1,0 +1,9 @@
+from .logger import configure, get_logger, _std_logging as _stdlib
+
+# Re-export names from the standard library logging module to minimise
+# surprises when this package shadows the builtin ``logging`` module.
+for _name in dir(_stdlib):
+    if _name not in globals():
+        globals()[_name] = getattr(_stdlib, _name)
+
+__all__ = list(dir(_stdlib)) + ["configure", "get_logger"]

--- a/logging/logger.py
+++ b/logging/logger.py
@@ -1,0 +1,50 @@
+import importlib.util
+import os
+from typing import Optional
+
+# Load the standard library logging module explicitly to avoid name clashes
+_stdlib_dir = os.path.dirname(os.__file__)
+_logging_path = os.path.join(_stdlib_dir, 'logging', '__init__.py')
+_spec = importlib.util.spec_from_file_location('stdlib_logging', _logging_path)
+_std_logging = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_std_logging)  # type: ignore
+
+LOG_LEVELS = {
+    'critical': _std_logging.CRITICAL,
+    'error': _std_logging.ERROR,
+    'warning': _std_logging.WARNING,
+    'info': _std_logging.INFO,
+    'debug': _std_logging.DEBUG,
+}
+
+
+def _resolve_level(level: Optional[str]) -> int:
+    """Resolve a textual level into a logging level constant."""
+    if level is None:
+        return _std_logging.INFO
+    if isinstance(level, int):
+        return level
+    return LOG_LEVELS.get(str(level).lower(), _std_logging.INFO)
+
+
+def configure(level: Optional[str] = None) -> _std_logging.Logger:
+    """Configure root logging.
+
+    Level may be provided as a string or resolved from the ``LOG_LEVEL``
+    environment variable. Returns the configured root logger.
+    """
+    if level is None:
+        level = os.getenv('LOG_LEVEL', 'info')
+    _std_logging.basicConfig(
+        level=_resolve_level(level),
+        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+    )
+    return _std_logging.getLogger()
+
+
+def get_logger(name: Optional[str] = None, level: Optional[str] = None) -> _std_logging.Logger:
+    """Return a logger with optional level override."""
+    logger = _std_logging.getLogger(name)
+    if level is not None:
+        logger.setLevel(_resolve_level(level))
+    return logger

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,9 @@
+from typing import Protocol
+
+
+class Plugin(Protocol):
+    """Plugin interface allowing custom reporters to be registered."""
+
+    def register(self, engine: 'Engine') -> None:  # noqa: F821
+        """Register the plugin with the engine."""
+        ...

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,0 +1,5 @@
+from .base import Reporter
+from .json_reporter import JSONReporter
+from .text_reporter import TextReporter
+
+__all__ = ["Reporter", "JSONReporter", "TextReporter"]

--- a/reports/base.py
+++ b/reports/base.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Reporter(ABC):
+    """Base class for all reporters."""
+
+    @abstractmethod
+    def handle(self, event: str, data: Any) -> None:
+        """Handle an event emitted by the engine."""
+
+    def finalize(self) -> None:
+        """Hook for cleanup after the engine finishes."""
+        return None

--- a/reports/json_reporter.py
+++ b/reports/json_reporter.py
@@ -1,0 +1,19 @@
+import json
+from typing import Any, List, Dict
+
+from .base import Reporter
+
+
+class JSONReporter(Reporter):
+    """Collect events and write them to a JSON file."""
+
+    def __init__(self, filename: str = 'report.json') -> None:
+        self.filename = filename
+        self._events: List[Dict[str, Any]] = []
+
+    def handle(self, event: str, data: Any) -> None:
+        self._events.append({'event': event, 'data': data})
+
+    def finalize(self) -> None:
+        with open(self.filename, 'w', encoding='utf-8') as fh:
+            json.dump(self._events, fh)

--- a/reports/text_reporter.py
+++ b/reports/text_reporter.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from .base import Reporter
+from logging.logger import get_logger
+
+
+class TextReporter(Reporter):
+    """Log engine events as plain text."""
+
+    def __init__(self, logger=None) -> None:
+        self.logger = logger or get_logger(__name__)
+
+    def handle(self, event: str, data: Any) -> None:
+        self.logger.info(f"{event}: {data}")

--- a/tui.py
+++ b/tui.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Simple text-based user interface with sidebar menu."""
+import curses
+import getpass
+
+MENU_ITEMS = ["Home", "Settings", "Config"]
+
+
+def draw_menu(stdscr: "curses._CursesWindow", selected: int) -> None:
+    """Render the sidebar and main content based on the selection."""
+    stdscr.clear()
+
+    sidebar_width = 20
+    for idx, item in enumerate(MENU_ITEMS):
+        mode = curses.A_REVERSE if idx == selected else curses.A_NORMAL
+        stdscr.addstr(idx + 1, 1, item, mode)
+
+    if MENU_ITEMS[selected] == "Home":
+        message = f"Hello {getpass.getuser()}"
+    elif MENU_ITEMS[selected] == "Settings":
+        message = "Settings screen"
+    else:
+        message = "Config screen"
+    stdscr.addstr(1, sidebar_width + 2, message)
+    stdscr.refresh()
+
+
+def main(stdscr: "curses._CursesWindow") -> None:
+    curses.curs_set(0)
+    stdscr.keypad(True)
+    selected = 0
+    draw_menu(stdscr, selected)
+    while True:
+        key = stdscr.getch()
+        if key in (curses.KEY_UP, ord("k")):
+            selected = (selected - 1) % len(MENU_ITEMS)
+        elif key in (curses.KEY_DOWN, ord("j")):
+            selected = (selected + 1) % len(MENU_ITEMS)
+        elif key in (ord("q"), 27):
+            break
+        draw_menu(stdscr, selected)
+
+
+if __name__ == "__main__":
+    curses.wrapper(main)

--- a/ui.py
+++ b/ui.py
@@ -1,0 +1,62 @@
+import argparse
+import json
+from typing import Any
+
+from logging import configure
+from engine import Engine
+from reports import JSONReporter, TextReporter
+
+
+def _parse_line(line: str) -> tuple[str, Any]:
+    """Split an input line into an event name and optional data.
+
+    Data is parsed as JSON if possible; otherwise it is returned as a raw
+    string. If no data is provided, ``None`` is returned.
+    """
+    if not line:
+        return "", None
+    if " " not in line:
+        return line, None
+    event, data_str = line.split(" ", 1)
+    try:
+        return event, json.loads(data_str)
+    except json.JSONDecodeError:
+        return event, data_str
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with the engine")
+    parser.add_argument(
+        "--json",
+        dest="json_path",
+        help="Write events to the given JSON file",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="info",
+        help="Logging level for the built-in logger",
+    )
+    args = parser.parse_args()
+
+    configure(args.log_level)
+    engine = Engine()
+    engine.register_reporter(TextReporter())
+    if args.json_path:
+        engine.register_reporter(JSONReporter(args.json_path))
+
+    print("Enter events as 'event [JSON_data]' (type 'quit' to exit)")
+    while True:
+        try:
+            line = input("> ").strip()
+        except EOFError:
+            break
+        if line.lower() in {"quit", "exit"}:
+            break
+        event, data = _parse_line(line)
+        if event:
+            engine.emit(event, data)
+    engine.finalize()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement logging wrapper with configurable levels
- add JSON and text reporters and tie them to engine events
- enable plugins to register custom reporters
- provide an interactive command-line interface for emitting events
- ignore compiled bytecode and drop committed pyc files

## Testing
- `pytest`